### PR TITLE
Add parallelism to Google Cloud Build steps

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -125,7 +125,7 @@ steps:
       - .
   - name: gcr.io/cloud-builders/docker
     id: run-test
-    waitFor: ['push-deploy', 'push-batch' 'push-train', 'push-predict']
+    waitFor: ['push-deploy', 'push-batch', 'push-train', 'push-predict']
     args:
       - run
       - '--network=cloudbuild'

--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 steps:
+  # deploy
   - name: gcr.io/cloud-builders/docker
+    id: pull-deploy
+    waitFor: ['-']
     args:
       - pull
       - 'gcr.io/llm-containers/deploy:latest'
   - name: gcr.io/cloud-builders/docker
+    id: build-deploy
+    waitFor: ['pull-deploy']
     args:
       - build
       - '-t'
@@ -27,14 +32,21 @@ steps:
       - docker/deploy.Dockerfile
       - .
   - name: gcr.io/cloud-builders/docker
+    id: push-deploy
+    waitFor: build-deploy
     args:
       - push
       - 'gcr.io/llm-containers/deploy:github${SHORT_SHA}'
+  # batch
   - name: gcr.io/cloud-builders/docker
+    id: pull-batch
+    waitFor: ['-']
     args:
       - pull
       - 'gcr.io/llm-containers/batch:latest'
   - name: gcr.io/cloud-builders/docker
+    id: build-batch
+    waitFor: pull-batch
     args:
       - build
       - '-t'
@@ -45,14 +57,21 @@ steps:
       - docker/batch.Dockerfile
       - .
   - name: gcr.io/cloud-builders/docker
+    id: push-batch
+    waitFor: build-batch
     args:
       - push
       - 'gcr.io/llm-containers/batch:github${SHORT_SHA}'
+  # train
   - name: gcr.io/cloud-builders/docker
+    id: pull-train
+    waitFor: ['-']
     args:
       - pull
       - 'gcr.io/llm-containers/train:latest'
   - name: gcr.io/cloud-builders/docker
+    id: build-train
+    waitFor: ['pull-train']
     args:
       - build
       - '-t'
@@ -63,14 +82,21 @@ steps:
       - docker/train.Dockerfile
       - .
   - name: gcr.io/cloud-builders/docker
+    id: push-train
+    waitFor: build-train
     args:
       - push
       - 'gcr.io/llm-containers/train:github${SHORT_SHA}'
+  #predict
   - name: gcr.io/cloud-builders/docker
+    id: pull-predict
+    waitFor: ['-']
     args:
       - pull
       - 'gcr.io/llm-containers/predict:latest'
   - name: gcr.io/cloud-builders/docker
+    id: build-predict
+    waitFor: ['pull-predict']
     args:
       - build
       - '-t'
@@ -81,10 +107,15 @@ steps:
       - docker/predict.Dockerfile
       - .
   - name: gcr.io/cloud-builders/docker
+    id: push-predict
+    waitFor: build-predict
     args:
       - push
       - 'gcr.io/llm-containers/predict:github${SHORT_SHA}'
+  # test
   - name: gcr.io/cloud-builders/docker
+    id: build-test
+    waitFor: ['-']
     args:
       - build
       - '-t'
@@ -93,6 +124,8 @@ steps:
       - docker/test.Dockerfile
       - .
   - name: gcr.io/cloud-builders/docker
+    id: run-test
+    waitFor: ['push-deploy', 'push-batch' 'push-train', 'push-predict']
     args:
       - run
       - '--network=cloudbuild'

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -125,7 +125,7 @@ steps:
       - .
   - name: gcr.io/cloud-builders/docker
     id: run-test
-    waitFor: ['push-deploy', 'push-batch' 'push-train', 'push-predict']
+    waitFor: ['push-deploy', 'push-batch', 'push-train', 'push-predict']
     args:
       - run
       - '--network=cloudbuild'

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 steps:
+  # deploy
   - name: gcr.io/cloud-builders/docker
+    id: pull-deploy
+    waitFor: ['-']
     args:
       - pull
       - 'gcr.io/llm-containers/deploy:latest'
   - name: gcr.io/cloud-builders/docker
+    id: build-deploy
+    waitFor: ['pull-deploy']
     args:
       - build
       - '-t'
@@ -27,14 +32,21 @@ steps:
       - docker/deploy.Dockerfile
       - .
   - name: gcr.io/cloud-builders/docker
+    id: push-deploy
+    waitFor: build-deploy
     args:
       - push
       - 'gcr.io/llm-containers/deploy:githubpr${_PR_NUMBER}'
+  # batch
   - name: gcr.io/cloud-builders/docker
+    id: pull-batch
+    waitFor: ['-']
     args:
       - pull
       - 'gcr.io/llm-containers/batch:latest'
   - name: gcr.io/cloud-builders/docker
+    id: build-batch
+    waitFor: pull-batch
     args:
       - build
       - '-t'
@@ -45,14 +57,21 @@ steps:
       - docker/batch.Dockerfile
       - .
   - name: gcr.io/cloud-builders/docker
+    id: push-batch
+    waitFor: build-batch
     args:
       - push
       - 'gcr.io/llm-containers/batch:githubpr${_PR_NUMBER}'
+  # train
   - name: gcr.io/cloud-builders/docker
+    id: pull-train
+    waitFor: ['-']
     args:
       - pull
       - 'gcr.io/llm-containers/train:latest'
   - name: gcr.io/cloud-builders/docker
+    id: build-train
+    waitFor: ['pull-train']
     args:
       - build
       - '-t'
@@ -63,14 +82,21 @@ steps:
       - docker/train.Dockerfile
       - .
   - name: gcr.io/cloud-builders/docker
+    id: push-train
+    waitFor: build-train
     args:
       - push
       - 'gcr.io/llm-containers/train:githubpr${_PR_NUMBER}'
+  #predict
   - name: gcr.io/cloud-builders/docker
+    id: pull-predict
+    waitFor: ['-']
     args:
       - pull
       - 'gcr.io/llm-containers/predict:latest'
   - name: gcr.io/cloud-builders/docker
+    id: build-predict
+    waitFor: ['pull-predict']
     args:
       - build
       - '-t'
@@ -81,10 +107,15 @@ steps:
       - docker/predict.Dockerfile
       - .
   - name: gcr.io/cloud-builders/docker
+    id: push-predict
+    waitFor: build-predict
     args:
       - push
       - 'gcr.io/llm-containers/predict:githubpr${_PR_NUMBER}'
+  # test
   - name: gcr.io/cloud-builders/docker
+    id: build-test
+    waitFor: ['-']
     args:
       - build
       - '-t'
@@ -93,6 +124,8 @@ steps:
       - docker/test.Dockerfile
       - .
   - name: gcr.io/cloud-builders/docker
+    id: run-test
+    waitFor: ['push-deploy', 'push-batch' 'push-train', 'push-predict']
     args:
       - run
       - '--network=cloudbuild'


### PR DESCRIPTION
Converts the PR and Nightly builds to run with parallel steps.

Right now this will lead to minor speed gains (~70 minutes down from ~75 minutes), but sets a framework for more tests in the future with minimal increase in time.