### PR TITLE
Set expiration on SSH keys used in training

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 steps:
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    script: |
-      # https://github.com/kyma-project/test-infra/issues/93#issuecomment-457263589
-      for i in $(gcloud compute os-login ssh-keys list | grep -v FINGERPRINT); do \
-          echo "Removing ssh key"; \
-          gcloud compute os-login ssh-keys remove --key $i || true; \
-      done
   - name: gcr.io/cloud-builders/docker
     args:
       - pull

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 steps:
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    script: |
-      # https://github.com/kyma-project/test-infra/issues/93#issuecomment-457263589
-      for i in $(gcloud compute os-login ssh-keys list | grep -v FINGERPRINT); do \
-          echo "Removing ssh key"; \
-          gcloud compute os-login ssh-keys remove --key $i || true; \
-      done
   - name: gcr.io/cloud-builders/docker
     args:
       - pull

--- a/scripts/train/setup_head.sh
+++ b/scripts/train/setup_head.sh
@@ -31,8 +31,12 @@ fi
 while read -r machine ip;
 do
   echo ${machine}
+  for i in $(gcloud compute os-login ssh-keys list | grep -v FINGERPRINT); do \
+    echo "Removing ssh key"; \
+    gcloud compute os-login ssh-keys remove --key $i || true; \
+  done
   while true; do
-    if gcloud compute ssh ${machine} --internal-ip --zone=${ZONE} --command="bash -l -c 'pip list | grep deepspeed'" --strict-host-key-checking=no -- -p 1022; then
+    if gcloud compute ssh ${machine} --internal-ip --zone=${ZONE} --command="bash -l -c 'pip list | grep deepspeed'" --ssh-key-expire-after=2m --strict-host-key-checking=no -- -p 1022; then
       break;
     fi
     echo "Waiting for ssh..."

--- a/scripts/train/setup_head.sh
+++ b/scripts/train/setup_head.sh
@@ -32,7 +32,7 @@ while read -r machine ip;
 do
   echo ${machine}
   while true; do
-    if gcloud compute ssh ${machine} --internal-ip --zone=${ZONE} --command="bash -l -c 'pip list | grep deepspeed'" --ssh-key-expire-after=2m --strict-host-key-checking=no -- -p 1022; then
+    if gcloud compute ssh ${machine} --internal-ip --zone=${ZONE} --command="bash -l -c 'pip list | grep deepspeed'" --ssh-key-expire-after=1d --strict-host-key-checking=no -- -p 1022; then
       break;
     fi
     echo "Waiting for ssh..."

--- a/scripts/train/setup_head.sh
+++ b/scripts/train/setup_head.sh
@@ -31,10 +31,6 @@ fi
 while read -r machine ip;
 do
   echo ${machine}
-  for i in $(gcloud compute os-login ssh-keys list | grep -v FINGERPRINT); do \
-    echo "Removing ssh key"; \
-    gcloud compute os-login ssh-keys remove --key $i || true; \
-  done
   while true; do
     if gcloud compute ssh ${machine} --internal-ip --zone=${ZONE} --command="bash -l -c 'pip list | grep deepspeed'" --ssh-key-expire-after=2m --strict-host-key-checking=no -- -p 1022; then
       break;


### PR DESCRIPTION
Sets an expiration on SSH keys created using `gcloud compute ssh`. This causes the ssh keys to be cleaned up in the login profile after approximately 1 day. Given that it takes several weeks for the profile to reach the 32kb limit, this should prevent us from running into the limit.