### PR TITLE
Change model_path to account for changes to gcsfs.recursive in Triton Image

### DIFF
--- a/src/predict_triton.py
+++ b/src/predict_triton.py
@@ -75,13 +75,12 @@ def download_model(model_path):
   logging.info("Model path: %s", model_path)
   if model_path.startswith("gs://"):
     src = model_path.replace("gs://", "")
-    dst = "/workspace/all_models/" + src.split("/")[-1] + "/"
-    app.model_directory = dst
+    dst = "/workspace/all_models/"
     gcs = gcsfs.GCSFileSystem()
     logging.info("Downloading model FROM %s", model_path)
     logging.info("Downloading model TO %s", dst)
     gcs.get(src, dst, recursive=True)
-    model_path = dst
+    model_path = dst + src.split("/")[-1] + "/"
 
   return model_path
 


### PR DESCRIPTION
Breaking changes to the `recursive` flag in package gcsfs>=2023.4.0 caused builds to start failing as the models were now downloaded to a directory in the form of /workspace/all_models/Model/Model instead of /workspace/all_models/Model.

This fixes the behavior by moving the reference of the name of the Source_Dir to after downloading the model.